### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/models/person.py
+++ b/models/person.py
@@ -55,7 +55,7 @@ class Fellow(Person):
     def __str__(self):
         choice = 'Y' if self.wants_living else 'N'
         name = self.name.upper()
-        return "FELLOW %s %s ID %d" % (name, choice, self.id)
+        return "FELLOW {0!s} {1!s} ID {2:d}".format(name, choice, self.id)
 
 
 class Staff(Person):
@@ -72,4 +72,4 @@ class Staff(Person):
 
     def __str__(self):
         name = name = self.name.upper()
-        return "STAFF %s ID %d" % (name, self.id)
+        return "STAFF {0!s} ID {1:d}".format(name, self.id)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:georgreen:Geoogreen-Mamboleo-Dojo-Project?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:georgreen:Geoogreen-Mamboleo-Dojo-Project?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)